### PR TITLE
Changed USERNAME env variable to HOST

### DIFF
--- a/lua/aw-watcher/utils.lua
+++ b/lua/aw-watcher/utils.lua
@@ -2,7 +2,7 @@ local has_notify, notify = pcall(require, "notify")
 local M = {}
 
 function M.get_username()
-  return os.getenv("USERNAME"):upper() -- other aw watchers capitalize this too...
+  return os.getenv("HOST"):upper() -- using host as username is a custom field
 end
 
 function M.get_timestamp()


### PR DESCRIPTION
Most other watcher use hostname of the device as a hostname, so I have changed to use the $HOST instead of custom env variable $USERNAME.